### PR TITLE
experiment: gkr custom gates

### DIFF
--- a/protocols/src/gkr/circuit.rs
+++ b/protocols/src/gkr/circuit.rs
@@ -48,7 +48,8 @@ impl Circuit {
 
             // exp_98 evaluations
             for wire in &layer.exp_98_gates {
-                layer_evaluations[wire.out] = (current_layer_input[wire.in_a] + current_layer_input[wire.in_b]).pow([98]);
+                layer_evaluations[wire.out] =
+                    (current_layer_input[wire.in_a] + current_layer_input[wire.in_b]).pow([98]);
             }
 
             current_layer_input = layer_evaluations.clone();
@@ -154,7 +155,7 @@ pub mod tests {
         let layer_2 = Layer::new(
             vec![Gate::new(2, 4, 5), Gate::new(3, 6, 7)],
             vec![Gate::new(0, 0, 1), Gate::new(1, 2, 3)],
-            vec![]
+            vec![],
         );
         Circuit::new(vec![layer_0, layer_1, layer_2]).unwrap()
     }
@@ -169,7 +170,7 @@ pub mod tests {
                 Gate::new(2, 4, 5),
                 Gate::new(3, 6, 7),
             ],
-            vec![]
+            vec![],
         );
         let layer_2 = Layer::new(
             vec![],
@@ -183,7 +184,7 @@ pub mod tests {
                 Gate::new(6, 3, 0),
                 Gate::new(7, 0, 5),
             ],
-            vec![]
+            vec![],
         );
         Circuit::new(vec![layer_0, layer_1, layer_2]).unwrap()
     }
@@ -307,7 +308,8 @@ pub mod tests {
         // circuit has 3 layers
 
         // layer 0 - output layer
-        let [add_0, mult_0, exp_98_0]: [MultiLinearPolynomial<Fr>; 3] = circuit.add_mul_mle(0).unwrap();
+        let [add_0, mult_0, exp_98_0]: [MultiLinearPolynomial<Fr>; 3] =
+            circuit.add_mul_mle(0).unwrap();
         // the number of variables for the add function should be 3
         assert_eq!(add_0.n_vars(), 3);
         // the number of variables for the mul function should be 0
@@ -326,7 +328,8 @@ pub mod tests {
         assert_eq!(sum_over_boolean_hyper_cube(&mult_0), Fr::from(0));
 
         // layer 1
-        let [add_1, mult_1, exp_98_1]: [MultiLinearPolynomial<Fr>; 3] = circuit.add_mul_mle(1).unwrap();
+        let [add_1, mult_1, exp_98_1]: [MultiLinearPolynomial<Fr>; 3] =
+            circuit.add_mul_mle(1).unwrap();
         // number of variables for add should be 5 (1 for current layer, then 2 each for next layer)
         assert_eq!(add_1.n_vars(), 5);
         // number of variables for mul should also be 5
@@ -363,7 +366,8 @@ pub mod tests {
         );
 
         // layer 2
-        let [add_2, mult_2, exp_98_2]: [MultiLinearPolynomial<Fr>; 3] = circuit.add_mul_mle(2).unwrap();
+        let [add_2, mult_2, exp_98_2]: [MultiLinearPolynomial<Fr>; 3] =
+            circuit.add_mul_mle(2).unwrap();
         // number of variables for add should be 8 (2 for current layer, then 3 each for next layer)
         assert_eq!(add_2.n_vars(), 8);
         // number of variables for mul should also be 8
@@ -485,8 +489,10 @@ pub mod tests {
         //  /   \    /   \
         // a     b  c     d
 
-        let circuit_a = Circuit::new(vec![Layer::new(vec![], vec![Gate::new(0, 0, 1)], vec![])]).unwrap();
-        let circuit_b = Circuit::new(vec![Layer::new(vec![Gate::new(1, 2, 3)], vec![], vec![])]).unwrap();
+        let circuit_a =
+            Circuit::new(vec![Layer::new(vec![], vec![Gate::new(0, 0, 1)], vec![])]).unwrap();
+        let circuit_b =
+            Circuit::new(vec![Layer::new(vec![Gate::new(1, 2, 3)], vec![], vec![])]).unwrap();
 
         // c = a + b
         let circuit_c = (circuit_a + circuit_b).unwrap();
@@ -500,7 +506,8 @@ pub mod tests {
 
     #[test]
     fn test_circuit_additive_identity() {
-        let circuit_a = Circuit::new(vec![Layer::new(vec![], vec![Gate::new(0, 0, 1)], vec![])]).unwrap();
+        let circuit_a =
+            Circuit::new(vec![Layer::new(vec![], vec![Gate::new(0, 0, 1)], vec![])]).unwrap();
         let circuit_b = Circuit::additive_identity(1);
         let circuit_c = (circuit_a.clone() + circuit_b).unwrap();
         assert_eq!(circuit_c, circuit_a);

--- a/protocols/src/gkr/gate_eval_extension.rs
+++ b/protocols/src/gkr/gate_eval_extension.rs
@@ -336,7 +336,7 @@ mod test {
 
         // construct relevant mles
         // add and mul mle from layer 1, (a, b, c) -> (len(1), len(2), len(2)) -> 5 total variables
-        let [add_1, mul_1] = circuit.add_mul_mle::<Fr>(1).unwrap();
+        let [add_1, mul_1, exp_1] = circuit.add_mul_mle::<Fr>(1).unwrap();
         // w_mle from layer 2 with len(2)
         let w_2 = Circuit::w(circuit_eval.as_slice(), 2).unwrap();
 
@@ -369,7 +369,7 @@ mod test {
     fn test_partial_evaluation() {
         let (circuit, circuit_eval) = evaluated_circuit();
 
-        let [add_1, mul_1] = circuit.add_mul_mle::<Fr>(1).unwrap();
+        let [add_1, mul_1, exp_1] = circuit.add_mul_mle::<Fr>(1).unwrap();
         let w_2 = Circuit::w(circuit_eval.as_slice(), 2).unwrap();
 
         let gate_eval_ext = GateEvalExtension::new(vec![Fr::from(10)], add_1, mul_1, w_2).unwrap();
@@ -413,7 +413,7 @@ mod test {
     fn test_to_univariate() {
         let (circuit, circuit_eval) = evaluated_circuit();
 
-        let [add_1, mul_1] = circuit.add_mul_mle::<Fr>(1).unwrap();
+        let [add_1, mul_1, exp_1] = circuit.add_mul_mle::<Fr>(1).unwrap();
         let w_2 = Circuit::w(circuit_eval.as_slice(), 2).unwrap();
 
         let gate_eval_ext = GateEvalExtension::new(vec![Fr::from(10)], add_1, mul_1, w_2).unwrap();
@@ -445,7 +445,7 @@ mod test {
     #[test]
     fn test_sum_check_eval() {
         let (circuit, circuit_eval) = evaluated_circuit();
-        let [add_1, mul_1] = circuit.add_mul_mle::<Fr>(1).unwrap();
+        let [add_1, mul_1, exp_1] = circuit.add_mul_mle::<Fr>(1).unwrap();
         let w_2 = Circuit::w(circuit_eval.as_slice(), 2).unwrap();
         let gate_eval_ext = GateEvalExtension::new(vec![Fr::from(0)], add_1, mul_1, w_2).unwrap();
 

--- a/protocols/src/gkr/gkr.rs
+++ b/protocols/src/gkr/gkr.rs
@@ -44,7 +44,7 @@ pub fn GKRProve<F: PrimeField>(
     for layer_index in 1..evaluations.len() {
         let [add_mle, mul_mle, exp_98_mle] = circuit.add_mul_mle(layer_index - 1)?;
         let w_i = Circuit::w(evaluations.as_slice(), layer_index)?;
-        let f_b_c = GateEvalExtension::new(r.clone(), add_mle, mul_mle, w_i.clone())?;
+        let f_b_c = GateEvalExtension::new(r.clone(), add_mle, mul_mle, exp_98_mle, w_i.clone())?;
 
         let (partial_sumcheck_proof, challenges) = Sumcheck::prove_partial(f_b_c, m);
         transcript.append(partial_sumcheck_proof.to_bytes().as_slice());
@@ -255,7 +255,7 @@ mod test {
         let layer_2 = Layer::new(
             vec![Gate::new(0, 0, 1), Gate::new(2, 4, 5)],
             vec![Gate::new(1, 2, 3)],
-            vec![]
+            vec![],
         );
 
         let circuit = Circuit::new(vec![layer_0, layer_1, layer_2]).unwrap();

--- a/protocols/src/gkr/gkr.rs
+++ b/protocols/src/gkr/gkr.rs
@@ -42,7 +42,7 @@ pub fn GKRProve<F: PrimeField>(
     // f(b, c) = add(r, b, c)(w_i(b) + w_i(c)) + mul(r, b, c)(w_i(b) * w_i(c))
     // each gkr round show that m = sum of f(b, c) over the boolean hypercube
     for layer_index in 1..evaluations.len() {
-        let [add_mle, mul_mle] = circuit.add_mul_mle(layer_index - 1)?;
+        let [add_mle, mul_mle, exp_98_mle] = circuit.add_mul_mle(layer_index - 1)?;
         let w_i = Circuit::w(evaluations.as_slice(), layer_index)?;
         let f_b_c = GateEvalExtension::new(r.clone(), add_mle, mul_mle, w_i.clone())?;
 
@@ -121,7 +121,7 @@ pub fn GKRVerify<F: PrimeField>(
         }
 
         let (b, c) = subclaim.challenges.split_at(subclaim.challenges.len() / 2);
-        let [add_mle, mul_mle] = circuit.add_mul_mle(layer_index)?;
+        let [add_mle, mul_mle, exp_98_mle] = circuit.add_mul_mle(layer_index)?;
         let mut rbc = r.clone();
         rbc.extend(&subclaim.challenges);
 
@@ -250,11 +250,12 @@ mod test {
 
     #[test]
     fn test_output_zero_gkr() {
-        let layer_0 = Layer::new(vec![], vec![Gate::new(0, 0, 1)]);
-        let layer_1 = Layer::new(vec![Gate::new(0, 0, 1)], vec![Gate::new(1, 1, 2)]);
+        let layer_0 = Layer::new(vec![], vec![Gate::new(0, 0, 1)], vec![]);
+        let layer_1 = Layer::new(vec![Gate::new(0, 0, 1)], vec![Gate::new(1, 1, 2)], vec![]);
         let layer_2 = Layer::new(
             vec![Gate::new(0, 0, 1), Gate::new(2, 4, 5)],
             vec![Gate::new(1, 2, 3)],
+            vec![]
         );
 
         let circuit = Circuit::new(vec![layer_0, layer_1, layer_2]).unwrap();

--- a/protocols/src/gkr/layer.rs
+++ b/protocols/src/gkr/layer.rs
@@ -8,17 +8,20 @@ use ark_ff::PrimeField;
 pub struct Layer {
     pub add_gates: Vec<Gate>,
     pub mul_gates: Vec<Gate>,
+    // Takes two inputs a, b and computes (a + b)^98
+    pub exp_98_gates: Vec<Gate>,
     len: usize,
 }
 
 impl Layer {
     /// Instantiate a new gate layer, calculate the total gate count
     // TODO: don't allow the creation of empty layers
-    pub fn new(add_gates: Vec<Gate>, mul_gates: Vec<Gate>) -> Self {
+    pub fn new(add_gates: Vec<Gate>, mul_gates: Vec<Gate>, exp_98_gates: Vec<Gate>) -> Self {
         Self {
             len: add_gates.len() + mul_gates.len(),
             add_gates,
             mul_gates,
+            exp_98_gates
         }
     }
 
@@ -40,7 +43,13 @@ impl Layer {
             .map(|gate| gate.in_a.max(gate.in_b) as isize)
             .max()
             .unwrap_or(-1);
-        max_add_gate_index.max(max_mul_gate_index)
+        let max_exp_98_gate_index = self
+            .exp_98_gates
+            .iter()
+            .map(|gate| gate.in_a.max(gate.in_b) as isize)
+            .max()
+            .unwrap_or(-1);
+        max_add_gate_index.max(max_mul_gate_index).max(max_exp_98_gate_index)
     }
 
     /// Generate the add_i and mult_i multilinear extension polynomials for the current layer
@@ -48,7 +57,7 @@ impl Layer {
     pub fn add_mul_mle<F: PrimeField>(
         &self,
         next_layer_count: usize,
-    ) -> [MultiLinearPolynomial<F>; 2] {
+    ) -> [MultiLinearPolynomial<F>; 3] {
         let layer_var_count = bit_count_for_n_elem(self.len);
         let next_layer_count = bit_count_for_n_elem(next_layer_count);
 
@@ -72,7 +81,17 @@ impl Layer {
             },
         );
 
-        [add_mle, mult_mle]
+        // construct selector poly for exp_98 gates
+        let exp_98_mle = self.exp_98_gates.iter().fold(
+            MultiLinearPolynomial::<F>::additive_identity(),
+            |acc, gate| {
+                let gate_bits = gate.to_bit_string(layer_var_count, next_layer_count);
+                let gate_bit_checker = MultiLinearPolynomial::<F>::bit_string_checker(gate_bits);
+                (&acc + &gate_bit_checker).unwrap()
+            }
+        );
+
+        [add_mle, mult_mle, exp_98_mle]
     }
 }
 
@@ -95,10 +114,11 @@ mod test {
                 Gate::new(6, 3, 0),
                 Gate::new(7, 0, 5),
             ],
+            vec![]
         );
         assert_eq!(layer.max_input_index(), 6);
 
-        let empty_layer = Layer::new(vec![], vec![]);
+        let empty_layer = Layer::new(vec![], vec![], vec![]);
         assert_eq!(empty_layer.max_input_index(), -1);
     }
 }

--- a/protocols/src/gkr/layer.rs
+++ b/protocols/src/gkr/layer.rs
@@ -18,7 +18,7 @@ impl Layer {
     // TODO: don't allow the creation of empty layers
     pub fn new(add_gates: Vec<Gate>, mul_gates: Vec<Gate>, exp_98_gates: Vec<Gate>) -> Self {
         Self {
-            len: add_gates.len() + mul_gates.len(),
+            len: add_gates.len() + mul_gates.len() + exp_98_gates.len(),
             add_gates,
             mul_gates,
             exp_98_gates

--- a/protocols/src/gkr/layer.rs
+++ b/protocols/src/gkr/layer.rs
@@ -21,7 +21,7 @@ impl Layer {
             len: add_gates.len() + mul_gates.len() + exp_98_gates.len(),
             add_gates,
             mul_gates,
-            exp_98_gates
+            exp_98_gates,
         }
     }
 
@@ -49,7 +49,9 @@ impl Layer {
             .map(|gate| gate.in_a.max(gate.in_b) as isize)
             .max()
             .unwrap_or(-1);
-        max_add_gate_index.max(max_mul_gate_index).max(max_exp_98_gate_index)
+        max_add_gate_index
+            .max(max_mul_gate_index)
+            .max(max_exp_98_gate_index)
     }
 
     /// Generate the add_i and mult_i multilinear extension polynomials for the current layer
@@ -88,7 +90,7 @@ impl Layer {
                 let gate_bits = gate.to_bit_string(layer_var_count, next_layer_count);
                 let gate_bit_checker = MultiLinearPolynomial::<F>::bit_string_checker(gate_bits);
                 (&acc + &gate_bit_checker).unwrap()
-            }
+            },
         );
 
         [add_mle, mult_mle, exp_98_mle]
@@ -114,7 +116,7 @@ mod test {
                 Gate::new(6, 3, 0),
                 Gate::new(7, 0, 5),
             ],
-            vec![]
+            vec![],
         );
         assert_eq!(layer.max_input_index(), 6);
 

--- a/protocols/src/r1cs_gkr/circuit.rs
+++ b/protocols/src/r1cs_gkr/circuit.rs
@@ -74,6 +74,7 @@ fn constraint_circuit<F: PrimeField>(
     let sign_layer = Layer::new(
         vec![],
         vec![a_mul_gate, b_mul_gate, c_mul_gate, minus_1_gate],
+        vec![]
     );
 
     // compute layer
@@ -90,8 +91,8 @@ fn constraint_circuit<F: PrimeField>(
         3 + product_layer_offset,
     );
     let compute_layer = match constraint.operation {
-        Operation::Add => Layer::new(vec![a_op_b_gate], vec![c_mul_minus_1]),
-        Operation::Mul => Layer::new(vec![], vec![a_op_b_gate, c_mul_minus_1]),
+        Operation::Add => Layer::new(vec![a_op_b_gate], vec![c_mul_minus_1], vec![]),
+        Operation::Mul => Layer::new(vec![], vec![a_op_b_gate, c_mul_minus_1], vec![]),
     };
 
     // output layer
@@ -100,7 +101,7 @@ fn constraint_circuit<F: PrimeField>(
         0 + compute_layer_offset,
         1 + compute_layer_offset,
     );
-    let output_layer = Layer::new(vec![output_gate], vec![]);
+    let output_layer = Layer::new(vec![output_gate], vec![], vec![]);
 
     GKRCircuit::new(vec![output_layer, compute_layer, sign_layer]).expect("should generate circuit")
 }

--- a/protocols/src/r1cs_gkr/circuit.rs
+++ b/protocols/src/r1cs_gkr/circuit.rs
@@ -74,7 +74,7 @@ fn constraint_circuit<F: PrimeField>(
     let sign_layer = Layer::new(
         vec![],
         vec![a_mul_gate, b_mul_gate, c_mul_gate, minus_1_gate],
-        vec![]
+        vec![],
     );
 
     // compute layer


### PR DESCRIPTION
NOT TO BE MERGED

Experiment to see if GKR custom gates are possible.

Defines new gate type: exp_98
- takes 2 inputs b, c computes (b + c)^98
- can prove and verify circuits built with this gate