### PR TITLE
feat: product poly

### DIFF
--- a/polynomial/src/lib.rs
+++ b/polynomial/src/lib.rs
@@ -3,6 +3,7 @@ use ark_ff::PrimeField;
 use self::univariate_poly::UnivariatePolynomial;
 
 pub mod multilinear;
+mod product_poly;
 pub mod univariate_poly;
 
 pub trait Polynomial<F: PrimeField>: Clone {

--- a/polynomial/src/multilinear/evaluation_form.rs
+++ b/polynomial/src/multilinear/evaluation_form.rs
@@ -67,7 +67,7 @@ impl<F: PrimeField> MultiLinearPolynomial<F> {
                         // left - r.left + r.right
                         // left - r (left - right)
                         left - *assignment * (left - right)
-                    },
+                    }
                 };
             }
         }

--- a/polynomial/src/multilinear/evaluation_form.rs
+++ b/polynomial/src/multilinear/evaluation_form.rs
@@ -78,6 +78,11 @@ impl<F: PrimeField> MultiLinearPolynomial<F> {
 
         Ok(self.partial_evaluate(0, assignments)?.evaluations[0])
     }
+
+    /// Returns the evaluations of the `MultilinearPolynomial` as a slice
+    pub fn evaluation_slice(&self) -> &[F] {
+        &self.evaluations
+    }
 }
 
 #[cfg(test)]

--- a/polynomial/src/multilinear/evaluation_form.rs
+++ b/polynomial/src/multilinear/evaluation_form.rs
@@ -1,7 +1,7 @@
 use crate::multilinear::pairing_index::PairingIndex;
 use ark_ff::PrimeField;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 /// `MultilinearPolynomial` (Dense Evaluation Representation)
 /// holds all evaluations over the boolean hypercube of an n_var multilinear polynomial
 pub struct MultiLinearPolynomial<F: PrimeField> {

--- a/polynomial/src/multilinear/evaluation_form.rs
+++ b/polynomial/src/multilinear/evaluation_form.rs
@@ -1,17 +1,18 @@
 use crate::multilinear::pairing_index::PairingIndex;
 use ark_ff::PrimeField;
 
+#[derive(Debug)]
 /// `MultilinearPolynomial` (Dense Evaluation Representation)
 /// holds all evaluations over the boolean hypercube of an n_var multilinear polynomial
-struct MultilinearPolynomial<F: PrimeField> {
+pub struct MultiLinearPolynomial<F: PrimeField> {
     n_vars: usize,
     evaluations: Vec<F>,
 }
 
-impl<F: PrimeField> MultilinearPolynomial<F> {
+impl<F: PrimeField> MultiLinearPolynomial<F> {
     /// Instantiates a new `MultilinearPolynomial` after ensuring variable count
     /// aligns with evaluation len
-    fn new(n_vars: usize, evaluations: Vec<F>) -> Result<Self, &'static str> {
+    pub fn new(n_vars: usize, evaluations: Vec<F>) -> Result<Self, &'static str> {
         // the evaluation vec length must exactly be equal to 2^n_vars
         // this is because we might not always be able to assume the appropriate
         // element to pad the vector with.
@@ -25,13 +26,18 @@ impl<F: PrimeField> MultilinearPolynomial<F> {
         })
     }
 
+    /// Returns the number of variables
+    pub(crate) fn n_vars(&self) -> usize {
+        self.n_vars
+    }
+
     /// Partially evaluate the `MultilinearPolynomial` at n consecutive variables
     /// e.g. f(a, b, c, d, e, f)
     /// we can pick a starting variable and supply n evaluation points
     /// f.partial_evaluate(1, [2, 3, 4])
     /// this partially evaluates 3 variables, starting at var b
     /// so b = 2, c = 3 and d = 4
-    fn partial_evaluate(
+    pub fn partial_evaluate(
         &self,
         initial_var: usize,
         assignments: &[F],
@@ -65,7 +71,7 @@ impl<F: PrimeField> MultilinearPolynomial<F> {
     }
 
     /// Evaluate the `MultilinearPolynomial` at n points
-    fn evaluate(&self, assignments: &[F]) -> Result<F, &'static str> {
+    pub fn evaluate(&self, assignments: &[F]) -> Result<F, &'static str> {
         if assignments.len() != self.n_vars {
             return Err("evaluate must assign to all variables");
         }
@@ -76,29 +82,29 @@ impl<F: PrimeField> MultilinearPolynomial<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::multilinear::evaluation_form::MultilinearPolynomial;
+    use crate::multilinear::evaluation_form::MultiLinearPolynomial;
     use ark_bls12_381::Fr;
 
     #[test]
     fn test_new_multilinear_poly() {
         // should not allow n_vars / evaluation count mismatch
-        let poly = MultilinearPolynomial::new(2, vec![Fr::from(3), Fr::from(1), Fr::from(2)]);
+        let poly = MultiLinearPolynomial::new(2, vec![Fr::from(3), Fr::from(1), Fr::from(2)]);
         assert_eq!(poly.is_err(), true);
-        let poly = MultilinearPolynomial::new(2, vec![Fr::from(3), Fr::from(1)]);
+        let poly = MultiLinearPolynomial::new(2, vec![Fr::from(3), Fr::from(1)]);
         assert_eq!(poly.is_err(), true);
 
         // correct inputs
-        let poly = MultilinearPolynomial::new(1, vec![Fr::from(3), Fr::from(1)]);
+        let poly = MultiLinearPolynomial::new(1, vec![Fr::from(3), Fr::from(1)]);
         assert_eq!(poly.is_err(), false);
         let poly =
-            MultilinearPolynomial::new(2, vec![Fr::from(3), Fr::from(1), Fr::from(2), Fr::from(5)]);
+            MultiLinearPolynomial::new(2, vec![Fr::from(3), Fr::from(1), Fr::from(2), Fr::from(5)]);
         assert_eq!(poly.is_err(), false);
     }
 
     #[test]
     fn test_partial_evaluate_single_variable() {
         let poly =
-            MultilinearPolynomial::new(2, vec![Fr::from(3), Fr::from(1), Fr::from(2), Fr::from(5)])
+            MultiLinearPolynomial::new(2, vec![Fr::from(3), Fr::from(1), Fr::from(2), Fr::from(5)])
                 .unwrap();
         assert_eq!(
             poly.partial_evaluate(0, &[Fr::from(5)])
@@ -111,7 +117,7 @@ mod tests {
     #[test]
     fn test_partial_evaluate_consecutive_variables() {
         // f(a, b, c) = 2ab + 3bc
-        let poly = MultilinearPolynomial::new(
+        let poly = MultiLinearPolynomial::new(
             3,
             vec![
                 Fr::from(0),
@@ -143,7 +149,7 @@ mod tests {
     #[test]
     fn test_full_evaluation() {
         // f(a, b, c) = 2ab + 3bc
-        let poly = MultilinearPolynomial::new(
+        let poly = MultiLinearPolynomial::new(
             3,
             vec![
                 Fr::from(0),

--- a/polynomial/src/product_poly.rs
+++ b/polynomial/src/product_poly.rs
@@ -1,6 +1,5 @@
 use crate::multilinear::evaluation_form::MultiLinearPolynomial;
 use ark_ff::PrimeField;
-use std::io::stdout;
 
 // TODO: add documentation
 // TODO: can be generalized further (more operations, not just mles too)

--- a/polynomial/src/product_poly.rs
+++ b/polynomial/src/product_poly.rs
@@ -31,6 +31,18 @@ impl<F: PrimeField> ProductPoly<F> {
             polynomials,
         })
     }
+
+    /// Evaluate the product poly using the following
+    /// P(x) = A(x).B(x).C(x)
+    pub fn evaluate(&self, assignments: &[F]) -> Result<F, &'static str> {
+        if assignments.len() != self.n_vars {
+            return Err("evaluate must assign to all variables");
+        }
+
+        self.polynomials.iter().try_fold(F::one(), |product, poly| {
+            poly.evaluate(assignments).map(|value| product * value)
+        })
+    }
 }
 
 #[cfg(test)]
@@ -63,5 +75,36 @@ mod tests {
         .unwrap();
         let prod_poly = ProductPoly::new(vec![mle_a, mle_b]);
         assert_eq!(prod_poly.is_err(), true);
+    }
+
+    #[test]
+    fn test_evaluate() {
+        // create prod_poly from mle's with the same number of variables
+        let mle_a = MultiLinearPolynomial::new(
+            2,
+            vec![Fr::from(2), Fr::from(8), Fr::from(10), Fr::from(14)],
+        )
+        .unwrap();
+        let mle_b = MultiLinearPolynomial::new(
+            2,
+            vec![Fr::from(2), Fr::from(8), Fr::from(10), Fr::from(22)],
+        )
+        .unwrap();
+        let mle_c = MultiLinearPolynomial::new(
+            2,
+            vec![Fr::from(2), Fr::from(8), Fr::from(10), Fr::from(22)],
+        )
+        .unwrap();
+
+        let direct_product = mle_a.evaluate(&[Fr::from(1), Fr::from(10)]).unwrap()
+            * mle_b.evaluate(&[Fr::from(1), Fr::from(10)]).unwrap()
+            * mle_c.evaluate(&[Fr::from(1), Fr::from(10)]).unwrap();
+
+        let prod_poly = ProductPoly::new(vec![mle_a, mle_b, mle_c]).unwrap();
+
+        assert_eq!(
+            prod_poly.evaluate(&[Fr::from(1), Fr::from(10)]).unwrap(),
+            direct_product
+        );
     }
 }

--- a/polynomial/src/product_poly.rs
+++ b/polynomial/src/product_poly.rs
@@ -1,8 +1,8 @@
 use crate::multilinear::evaluation_form::MultiLinearPolynomial;
 use ark_ff::PrimeField;
 
-// TODO: add documentation
-// TODO: can be generalized further (more operations, not just mles too)
+// TODO: should be able to generalize this over the operation ie. not just product
+/// Represents the product of one or more `Multilinear` polynomials
 /// P(x) = A(x).B(x).C(x)
 #[derive(Debug, PartialEq)]
 struct ProductPoly<F: PrimeField> {

--- a/polynomial/src/product_poly.rs
+++ b/polynomial/src/product_poly.rs
@@ -1,0 +1,67 @@
+use crate::multilinear::evaluation_form::MultiLinearPolynomial;
+use ark_ff::PrimeField;
+
+// TODO: add documentation
+// TODO: can be generalized further (more operations, not just mles too)
+/// P(x) = A(x).B(x).C(x)
+#[derive(Debug)]
+struct ProductPoly<F: PrimeField> {
+    n_vars: usize,
+    polynomials: Vec<MultiLinearPolynomial<F>>,
+}
+
+impl<F: PrimeField> ProductPoly<F> {
+    /// Instantiate a new product_poly from a set of `Multilinear` polynomials
+    pub fn new(polynomials: Vec<MultiLinearPolynomial<F>>) -> Result<Self, &'static str> {
+        if polynomials.len() == 0 {
+            return Err("cannot create product polynomial from empty polynomials");
+        }
+
+        // ensure that all polynomials share the same number of variables
+        let expected_num_of_vars = polynomials[0].n_vars();
+        let equal_variables = polynomials
+            .iter()
+            .all(|poly| poly.n_vars() == expected_num_of_vars);
+        if !equal_variables {
+            return Err("cannot create product polynomial from polynomial that don't share the same number of variables");
+        }
+
+        Ok(Self {
+            n_vars: expected_num_of_vars,
+            polynomials,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::multilinear::evaluation_form::MultiLinearPolynomial;
+    use crate::product_poly::ProductPoly;
+    use ark_bls12_381::Fr;
+
+    #[test]
+    fn test_product_poly_creation() {
+        // create prod_poly from mle's with the same number of variables
+        let mle_a = MultiLinearPolynomial::new(
+            2,
+            vec![Fr::from(2), Fr::from(8), Fr::from(10), Fr::from(14)],
+        )
+        .unwrap();
+        let mle_b = MultiLinearPolynomial::new(
+            2,
+            vec![Fr::from(2), Fr::from(8), Fr::from(10), Fr::from(22)],
+        )
+        .unwrap();
+        let prod_poly = ProductPoly::new(vec![mle_a, mle_b]).unwrap();
+
+        // create prod_poly from mle's with different number of variables
+        let mle_a = MultiLinearPolynomial::new(1, vec![Fr::from(2), Fr::from(8)]).unwrap();
+        let mle_b = MultiLinearPolynomial::new(
+            2,
+            vec![Fr::from(2), Fr::from(8), Fr::from(10), Fr::from(22)],
+        )
+        .unwrap();
+        let prod_poly = ProductPoly::new(vec![mle_a, mle_b]);
+        assert_eq!(prod_poly.is_err(), true);
+    }
+}


### PR DESCRIPTION
Implements new polynomial structure that represents the product of n multilinear polynomials.

This represents the first step in a line of PR's to add support for the libra linear time sumcheck / gkr
- [x] product_poly
- [ ] sumcheck over product_poly
- [ ] gkr over product_poly
- [ ] take advantage of sparsity in gkr (i.e linear time sumcheck / gkr)