### PR TITLE
feat: pass transcript to sumcheck

### DIFF
--- a/libra/src/lib.rs
+++ b/libra/src/lib.rs
@@ -1,1 +1,2 @@
 // beginning of libra work
+// take transcript into sumcheck prover

--- a/sumcheck/src/lib.rs
+++ b/sumcheck/src/lib.rs
@@ -36,6 +36,7 @@ mod tests {
     use polynomial::multilinear::coefficient_form::CoeffMultilinearPolynomial;
     use polynomial::multilinear::evaluation_form::MultiLinearPolynomial;
     use polynomial::product_poly::ProductPoly;
+    use transcript::Transcript;
 
     fn p_2ab_3bc() -> MultiLinearPolynomial<Fr> {
         let evaluations = CoeffMultilinearPolynomial::new(
@@ -55,9 +56,14 @@ mod tests {
         // p = 2ab + 3bc
         let p = p_2ab_3bc();
         let prod_poly = ProductPoly::new(vec![p]).unwrap();
-        let proof = SumcheckProver::<1, Fr>::prove(prod_poly.clone(), Fr::from(10)).unwrap();
+        let mut transcript = Transcript::new();
+        let proof =
+            SumcheckProver::<1, Fr>::prove(prod_poly.clone(), Fr::from(10), &mut transcript)
+                .unwrap();
+
+        let mut transcript = Transcript::new();
         let verification_result =
-            SumcheckVerifier::verify(prod_poly, proof).expect("proof is invalid");
+            SumcheckVerifier::verify(prod_poly, proof, &mut transcript).expect("proof is invalid");
         assert!(verification_result);
     }
 
@@ -96,8 +102,10 @@ mod tests {
 
         let p = ProductPoly::new(vec![p1, p2]).unwrap();
 
-        let proof = SumcheckProver::<2, Fr>::prove(p.clone(), Fr::from(5)).unwrap();
-        let verification_result = SumcheckVerifier::verify(p, proof).expect("proof is invalid");
+        let proof =
+            SumcheckProver::<2, Fr>::prove(p.clone(), Fr::from(5), &mut Transcript::new()).unwrap();
+        let verification_result =
+            SumcheckVerifier::verify(p, proof, &mut Transcript::new()).expect("proof is invalid");
         assert!(verification_result);
     }
 
@@ -105,9 +113,14 @@ mod tests {
     fn test_correct_sum_prove_partial() {
         let p = p_2ab_3bc();
         let prod_poly = ProductPoly::new(vec![p]).unwrap();
-        let (proof, _) =
-            SumcheckProver::<1, Fr>::prove_partial(prod_poly.clone(), Fr::from(10)).unwrap();
-        let subclaim = SumcheckVerifier::verify_partial(proof).expect("proof is invalid");
+        let (proof, _) = SumcheckProver::<1, Fr>::prove_partial(
+            prod_poly.clone(),
+            Fr::from(10),
+            &mut Transcript::new(),
+        )
+        .unwrap();
+        let subclaim = SumcheckVerifier::verify_partial(proof, &mut Transcript::new())
+            .expect("proof is invalid");
         let expected_sum = prod_poly.evaluate(subclaim.challenges.as_slice()).unwrap();
         assert_eq!(expected_sum, subclaim.sum);
     }
@@ -117,7 +130,9 @@ mod tests {
         // p = 2ab + 3bc
         let p = p_2ab_3bc();
         let prod_poly = ProductPoly::new(vec![p]).unwrap();
-        let proof = SumcheckProver::<1, Fr>::prove(prod_poly.clone(), Fr::from(12)).unwrap();
-        assert!(SumcheckVerifier::verify(prod_poly, proof).is_err());
+        let proof =
+            SumcheckProver::<1, Fr>::prove(prod_poly.clone(), Fr::from(12), &mut Transcript::new())
+                .unwrap();
+        assert!(SumcheckVerifier::verify(prod_poly, proof, &mut Transcript::new()).is_err());
     }
 }

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -12,11 +12,14 @@ pub struct SumcheckProver<const MAX_VAR_DEGREE: u8, F: PrimeField> {
 
 impl<const MAX_VAR_DEGREE: u8, F: PrimeField> SumcheckProver<MAX_VAR_DEGREE, F> {
     /// Generates the `Sumcheck` proof (appends the initial poly to the transcript)
-    pub fn prove(poly: ProductPoly<F>, sum: F) -> Result<SumcheckProof<F>, &'static str> {
-        let mut transcript = Transcript::new();
+    pub fn prove(
+        poly: ProductPoly<F>,
+        sum: F,
+        transcript: &mut Transcript,
+    ) -> Result<SumcheckProof<F>, &'static str> {
         transcript.append(poly.to_bytes().as_slice());
 
-        Ok(Self::prove_internal(poly, sum, &mut transcript)?.0)
+        Ok(Self::prove_internal(poly, sum, transcript)?.0)
     }
 
     /// Generates the `Sumcheck` proof, but doesn't append the initial poly to the transcript.
@@ -24,9 +27,9 @@ impl<const MAX_VAR_DEGREE: u8, F: PrimeField> SumcheckProver<MAX_VAR_DEGREE, F> 
     pub fn prove_partial(
         poly: ProductPoly<F>,
         sum: F,
+        transcript: &mut Transcript,
     ) -> Result<(SumcheckProof<F>, Vec<F>), &'static str> {
-        let mut transcript = Transcript::new();
-        Self::prove_internal(poly, sum, &mut transcript)
+        Self::prove_internal(poly, sum, transcript)
     }
 
     /// Main `Sumcheck` proof generation logic.

--- a/sumcheck/src/verifier.rs
+++ b/sumcheck/src/verifier.rs
@@ -12,16 +12,19 @@ pub struct SumcheckVerifier<F: PrimeField> {
 
 impl<F: PrimeField> SumcheckVerifier<F> {
     /// Verify a `Sumcheck` proof (verifier has access to the initial poly or its commitment)
-    pub fn verify(poly: ProductPoly<F>, proof: SumcheckProof<F>) -> Result<bool, &'static str> {
+    pub fn verify(
+        poly: ProductPoly<F>,
+        proof: SumcheckProof<F>,
+        transcript: &mut Transcript,
+    ) -> Result<bool, &'static str> {
         // number of round_poly in the proof should match n_vars
         if proof.round_polys.len() != poly.n_vars() {
             return Err("invalid proof: require 1 round poly for each variable in poly");
         }
 
-        let mut transcript = Transcript::new();
         transcript.append(poly.to_bytes().as_slice());
 
-        let subclaim = Self::verify_internal(proof, &mut transcript)?;
+        let subclaim = Self::verify_internal(proof, transcript)?;
 
         // final verifier check
         // p_v(r_v) = p(r_1, r_2, ..., r_v)
@@ -35,9 +38,11 @@ impl<F: PrimeField> SumcheckVerifier<F> {
     /// Verify a `Sumcheck` proof (when the veifier doesn't have access to the initial poly or its commitment)
     /// in such a case, the verifier performs all checks other than the last check.
     /// Returns a subclaim that can later be used for that final check verification.
-    pub fn verify_partial(proof: SumcheckProof<F>) -> Result<SubClaim<F>, &'static str> {
-        let mut transcript = Transcript::new();
-        Self::verify_internal(proof, &mut transcript)
+    pub fn verify_partial(
+        proof: SumcheckProof<F>,
+        transcript: &mut Transcript,
+    ) -> Result<SubClaim<F>, &'static str> {
+        Self::verify_internal(proof, transcript)
     }
 
     /// Main `Sumcheck` verification logic.


### PR DESCRIPTION
- before the sumcheck prover and verifier create a new instance of the transcript when called, but this doesn't take into account the use of sumcheck as a subprotocol in bigger protocols.